### PR TITLE
icy-meta-parser show StreamTitles   - without decoder-errors

### DIFF
--- a/components/http/http.c
+++ b/components/http/http.c
@@ -20,8 +20,8 @@
 
 
 #define TAG "http_client"
-
-
+int icymeta,httpmeta;
+char icymeta_text[64];
 /**
  * @brief simple http_get
  * see https://github.com/nodejs/http-parser for callback usage
@@ -77,7 +77,10 @@ int http_client_get(char *uri, http_parser_settings *callbacks, void *user_data)
 
     // write http request
     char *request;
-    if(asprintf(&request, "GET %s HTTP/1.0\r\nHost: %s:%d\r\nUser-Agent: ESP32\r\nAccept: */*\r\n\r\n", url->path, url->host, url->port) < 0)
+//    if(asprintf(&request, "GET %s HTTP/1.0\r\nHost: %s:%d\r\nUser-Agent: ESP32\r\nAccept: */*\r\n\r\n", url->path, url->host, url->port) < 0)
+
+	    if(asprintf(&request, "%s%s%s%s%s%s%s%s%s", "GET ", url->path, " HTTP/1.0\r\nHost: ", url->host, "\r\n","User-Agent: ESP32\r\n","Range: bytes=0-\r\n","Connection: close\r\n","Icy-MetaData: 1\r\n\r\n") < 0)
+
     {
         return ESP_FAIL;
     }
@@ -94,6 +97,7 @@ int http_client_get(char *uri, http_parser_settings *callbacks, void *user_data)
 
 
     /* Read HTTP response */
+    int i,k=0,k1=0,k2=0;httpmeta=1;icymeta=0;//icy-metaint Parser
     char recv_buf[64];
     bzero(recv_buf, sizeof(recv_buf));
     ssize_t recved;
@@ -108,6 +112,42 @@ int http_client_get(char *uri, http_parser_settings *callbacks, void *user_data)
     esp_err_t nparsed = 0;
     do {
         recved = read(sock, recv_buf, sizeof(recv_buf)-1);
+
+    //icy-metaint Parser dedect icy-metaint: for spiram_fifo.c    
+    if(k2<1000) {
+       k2++;
+         if(k!=0)  { 
+            i=k;
+            if (recv_buf[k-i] == 0x69&&k==1)  k++;   //i
+            if (recv_buf[k-i] == 0x6e&&k==2)  k++;   //n
+            if (recv_buf[k-i] == 0x74&&k==3)  k++;   //t
+            if (recv_buf[k-i] == 0x3a&&k==4)  k++;    //:
+            if (k==5) {k1=recv_buf[k-i]-0x30; k++;} //Zahl
+            k1=k1*10000+(recv_buf[k-i]-0x30)*1000;  //Zahl
+               if(k<5)   
+                  k1=0;
+                  k=0;
+         };    
+
+
+         if(k1==0)  {
+            for (i=0;i<recved;i++) {
+               if (recv_buf[i] == 0x61){k++;if(i>=recved) break;      //a
+               if (recv_buf[i+k] == 0x69){k++;if(i+k>=recved) break;  //i
+               if (recv_buf[i+k] == 0x6e){k++;if(i+k>=recved) break;  //n
+               if (recv_buf[i+k] == 0x74){k++;if(i+k>=recved) break;  //t
+               if (recv_buf[i+k] == 0x3a){k++;if(i+k>=recved) break;  //:
+               k1=recv_buf[i+k]-0x30;k++;if(i+k>=recved) break;       //Zahl
+               k1=k1*10000+(recv_buf[i+k]-0x30)*1000;k=0;
+               icymeta=k1; //icy-metaint: found
+               printf("icy-metaint: k1=%d\n",k1);
+               k2=1000;
+               break;}
+               }}}} k=0;
+            }
+         };
+
+       };
 
         // using http parser causes stack overflow somtimes - disable for now
         nparsed = http_parser_execute(&parser, callbacks, recv_buf, recved);

--- a/components/http/include/http.h
+++ b/components/http/include/http.h
@@ -16,6 +16,8 @@
 typedef esp_err_t (*stream_reader_cb)(char *recv_buf, ssize_t bytes_read, void *user_data);
 
 int http_client_get(char *uri, http_parser_settings *callbacks, void *user_data);
-
+//icy-metaint-parser 
+int icymeta,httpmeta;
+char icymeta_text[64];
 
 #endif

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -137,7 +137,14 @@ void app_main()
     start_wifi();
     start_web_radio();
 #endif
-
     ESP_LOGI(TAG, "RAM left %d", esp_get_free_heap_size());
     // ESP_LOGI(TAG, "app_main stack: %d\n", uxTaskGetStackHighWaterMark(NULL));
+
+    while (1) {
+      vTaskDelay(40/portTICK_RATE_MS);
+//example Monitoring new  StreamTitle
+if(icymeta_text[62]==0xff) {
+printf("\nStreamTitle found \n %s \n",icymeta_text);
+icymeta_text[62]=0xee;     }
+    }
 }


### PR DESCRIPTION
How to use:
-if no icy-metadata available we recieve only Streamtitle=''; 
-If you get many errors "...bad data pointer..."  ,"...sync-error..."  my parser is out of sync and needs reset. This was the main-Problem with icy-metadatas the parser should solve.

If the conection is not stable may be its better switch off the parser, 
when you change lines 80 / 82 in http.c

-recommend  fetch icy-metadata in app_main.c to work with icymeta_text[] see example

My config:
ESP32  4MB, no external RAM ,