### PR TITLE
Icy metadata support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.project
 /sdkconfig
 /sdkconfig.old
+/.vscode

--- a/components/http/http.c
+++ b/components/http/http.c
@@ -21,6 +21,10 @@
 
 #define TAG "http_client"
 
+char icymeta_text[ICY_META_BUFF_LEN];
+
+bool newHttpRequest = false;
+int icymeta_interval = 0;
 
 /**
  * @brief simple http_get
@@ -77,7 +81,10 @@ int http_client_get(char *uri, http_parser_settings *callbacks, void *user_data)
 
     // write http request
     char *request;
-    if(asprintf(&request, "GET %s HTTP/1.0\r\nHost: %s:%d\r\nUser-Agent: ESP32\r\nAccept: */*\r\n\r\n", url->path, url->host, url->port) < 0)
+    if (asprintf(&request, "%s%s%s%s%s%s%s%s%s", "GET ", url->path,
+                 " HTTP/1.0\r\n", "Host:", url->host, "\r\n",
+                 "User-Agent: ESP32\r\n", "Accept: */*\r\n",
+                 "Icy-MetaData: 1\r\n\r\n") < 0)
     {
         return ESP_FAIL;
     }
@@ -92,8 +99,10 @@ int http_client_get(char *uri, http_parser_settings *callbacks, void *user_data)
     free(request);
     ESP_LOGI(TAG, "... socket send success");
 
-
     /* Read HTTP response */
+    newHttpRequest = true;
+    icymeta_interval = 0; // icy-metaint Parser
+
     char recv_buf[64];
     bzero(recv_buf, sizeof(recv_buf));
     ssize_t recved;

--- a/components/http/include/http.h
+++ b/components/http/include/http.h
@@ -18,4 +18,20 @@ typedef esp_err_t (*stream_reader_cb)(char *recv_buf, ssize_t bytes_read, void *
 int http_client_get(char *uri, http_parser_settings *callbacks, void *user_data);
 
 
+// icy-metaint-parser
+
+#define min(a, b)                                                              \
+    ({                                                                         \
+        __typeof__(a) _a = (a);                                                \
+        __typeof__(b) _b = (b);                                                \
+        _a < _b ? _a : _b;                                                     \
+    })
+
+#define ICY_META_BUFF_LEN 128
+
+extern char icymeta_text[ICY_META_BUFF_LEN];
+
+extern bool newHttpRequest;
+extern int icymeta_interval;
+
 #endif

--- a/components/libfaad/ps_dec.c
+++ b/components/libfaad/ps_dec.c
@@ -252,7 +252,9 @@ static void hybrid_free(hyb_info *hyb)
             faad_free(hyb->temp[i]);
     }
     if (hyb->temp)
+    {
         faad_free(hyb->temp);
+    }
 
 	faad_free(hyb);
 }


### PR DESCRIPTION
- decodes `icy-metaint` field from header to get the interval
- properly processes the metadata and prints it to monitor, do with it as you please

note: metadata is cleared after single cycle if meta length of the next cycle is 0. the conditional can be easily modified to support persisting it accross empty meta payloads

edit: added brackets to condition in ps_dec.c